### PR TITLE
Set path the back gets send to based on the environment name.

### DIFF
--- a/cloudformation/mongo-backup.yml
+++ b/cloudformation/mongo-backup.yml
@@ -171,7 +171,7 @@ Resources:
       Environment:
         Variables:
           BUCKET: !Sub net-platform-mongodb-snapshots-${env}
-          ROOT_PATH: /
+          ROOT_PATH: !Sub '/${env}/'
           URL:
             Fn::Join:
               - ""


### PR DESCRIPTION
Prepend env name to backup folder in S3 to avoid collisions when they are replicated to the backup account